### PR TITLE
IPFS url fixes

### DIFF
--- a/_data/chains/eip155-2730.json
+++ b/_data/chains/eip155-2730.json
@@ -1,6 +1,6 @@
 {
     "name": "XR Sepolia",
-    "chain": "txr",
+    "chain": "ETH",
     "rpc": [
         "https://xr-sepolia-testnet.rpc.caldera.xyz/http"
     ],

--- a/_data/chains/eip155-2730.json
+++ b/_data/chains/eip155-2730.json
@@ -1,28 +1,43 @@
 {
     "name": "XR Sepolia",
-    "shortName": "txr",
-    "chainId": 2730,
-    "networkId": 2730,
-    "chain": "ETH",
+    "chain": "txr",
+    "rpc": [
+        "https://xr-sepolia-testnet.rpc.caldera.xyz/http"
+    ],
+    "faucets": [],
     "nativeCurrency": {
         "name": "tXR",
         "symbol": "tXR",
         "decimals": 18
-      },
-    "rpc": ["https://xr-sepolia-testnet.rpc.caldera.xyz/http"],
-    "faucets": [],
-    "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+    },
+    "features": [
+        {
+            "name": "EIP155"
+        },
+        {
+            "name": "EIP1559"
+        }
+    ],
     "infoURL": "https://xr-one.gitbook.io",
+    "shortName": "txr",
+    "chainId": 2730,
+    "networkId": 2730,
     "icon": "xr",
-    "explorers": [{
-        "name": "XR Sepolia Explorer",
-        "url": "https://xr-sepolia-testnet.explorer.caldera.xyz",
-        "icon": "blockscout",
-        "standard": "EIP3091"
-    }],
+    "explorers": [
+        {
+            "name": "XR Sepolia Explorer",
+            "url": "https://xr-sepolia-testnet.explorer.caldera.xyz",
+            "icon": "xr",
+            "standard": "EIP3091"
+        }
+    ],
     "parent": {
-        "type" : "L2",
+        "type": "L2",
         "chain": "eip155-421614",
-        "bridges": [ {"url":"https://xr-sepolia-testnet.bridge.caldera.xyz"} ]
+        "bridges": [
+            {
+                "url": "https://xr-sepolia-testnet.bridge.caldera.xyz"
+            }
+        ]
     }
 }

--- a/_data/icons/xr.json
+++ b/_data/icons/xr.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "ipfs://QmP3fmsWoo4fFLXqDkrx21FATWJKJp1yuS8qUQqZCVndrE",
+    "url": "ipfs://Qma3wvNpLZjUKed4LDZM3qtw52GLsc8MZWHzjdPxrQznZo/XR-Round-Icon-Green.png",
     "width": 886,
     "height": 886,
     "format": "png"

--- a/_data/icons/xr.json
+++ b/_data/icons/xr.json
@@ -1,8 +1,8 @@
 [
-    {
-      "url": "ipfs://Qma3wvNpLZjUKed4LDZM3qtw52GLsc8MZWHzjdPxrQznZo/XR-Round-Icon-Green.png",
-      "width": 886,
-      "height": 886,
-      "format": "png"
-    }
+  {
+    "url": "ipfs://QmP3fmsWoo4fFLXqDkrx21FATWJKJp1yuS8qUQqZCVndrE",
+    "width": 886,
+    "height": 886,
+    "format": "png"
+  }
 ]

--- a/_data/icons/xr.json
+++ b/_data/icons/xr.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "ipfs://Qma3wvNpLZjUKed4LDZM3qtw52GLsc8MZWHzjdPxrQznZo/XR-Round-Icon-Green.png",
+    "url": "ipfs://QmP3fmsWoo4fFLXqDkrx21FATWJKJp1yuS8qUQqZCVndrE",
     "width": 886,
     "height": 886,
     "format": "png"


### PR DESCRIPTION
1. IPFS url of xr had sub-directory, many other successful commits did not. Testing this with new link.
2. Blockscout had publicly unresolvable IPFS link, switched to xr.